### PR TITLE
Updated requirement and release note

### DIFF
--- a/openai/release_notes.md
+++ b/openai/release_notes.md
@@ -1,4 +1,4 @@
 #### What's Improved
 - Added a new configuration parameter `Verify SSL`.
-- Initialized httpx client with proxy if proxy is configured in the environment.
+- Added Network Proxy support. API call to openai endpoint will be routed via the network proxy if proxy is configured for the FortiSOAR instance.
 

--- a/openai/requirements.txt
+++ b/openai/requirements.txt
@@ -2,4 +2,4 @@
 openai>=1.0.0
 jsonschema
 tiktoken
-httpx>=0.27.0
+httpx>=0.26.0

--- a/openai/requirements.txt
+++ b/openai/requirements.txt
@@ -2,4 +2,4 @@
 openai>=1.0.0
 jsonschema
 tiktoken
-httpx
+httpx>=0.27.0


### PR DESCRIPTION
#### Changes:
- Updated release notes.
- The `proxy` argument introduced in `httpx==0.26.0` version. 

#### UTC:
- [x] Tested and verified connector health with httpx==0.26.0 and httpx==0.27.0(latest) version
