### PR TITLE
Handle different status of OpenAI Thread Run

### DIFF
--- a/openai/assistant_event_handler.py
+++ b/openai/assistant_event_handler.py
@@ -22,7 +22,7 @@ class EventHandler(AssistantEventHandler):
     def __init__(self, config, params, last_message_id):
         super().__init__()
         self.run_id = None
-        self.response = {'status': 1, 'messages': []}
+        self.response = {'status': 0, 'message': []}
         self.config = config
         self.params = params
         self.tool_outputs = []
@@ -124,7 +124,7 @@ class EventHandler(AssistantEventHandler):
 
     @override
     def on_end(self):
-        if self.response['status'] == 0:
+        if self.response['status'] == 1:
             return
 
         run_payload = {'run_id': self.run_id, 'thread_id': self.params['thread_id']}
@@ -132,7 +132,7 @@ class EventHandler(AssistantEventHandler):
         while True:
             run_object = get_run(config=self.config, params=run_payload)
             status = run_object['status']
-            logger.info(f'Run Status: {status}')
+            logger.debug(f'Run Status: {status}')
             if status in RUN_FINAL_STATUS:
                 break
 
@@ -144,7 +144,7 @@ class EventHandler(AssistantEventHandler):
                 f"\nRun Id: {run_object.get('id')} \nAssistant Id: {run_object.get('assistant_id')}"
             )
             logger.error(detailed_error_message)
-            self.response.update({'status': 0, 'message': error_message})
+            self.response.update({'status': 1, 'message': error_message})
             return
 
         self.response['message'] = list_thread_messages(
@@ -161,14 +161,14 @@ class EventHandler(AssistantEventHandler):
     def on_exception(self, exception: Exception) -> None:
         error_message = f"Exception occurred while executing thread: {exception}"
         logger.error(error_message)
-        self.response.update({'status': 0, 'message': error_message})
+        self.response.update({'status': 1, 'message': error_message})
 
     def _get_error_message(self, status, run_object):
         """Helper method to get the error message based on the status."""
         if status == "incomplete":
             reason = run_object.get("incomplete_details", {}).get("reason", "unknown")
-            details = run_object.get(reason, "No additional info")
-            return RUN_STATUS_ERROR_MESSAGES[status].format(reason=reason, details=details)
+            limit = run_object.get(reason, "No additional info")
+            return RUN_STATUS_ERROR_MESSAGES[status].format(reason=reason, limit=limit)
         elif status == "failed":
             error_message = run_object.get("last_error", {}).get("message", "No details available")
             return RUN_STATUS_ERROR_MESSAGES[status].format(error_message=error_message)

--- a/openai/assistant_event_handler.py
+++ b/openai/assistant_event_handler.py
@@ -4,6 +4,8 @@ MIT License
 Copyright (c) 2025 Fortinet Inc
 Copyright end
 """
+import copy
+
 from typing_extensions import override
 from openai import AssistantEventHandler
 from openai.types.beta.threads.runs import RunStepDelta
@@ -13,7 +15,7 @@ from openai.types.beta import AssistantStreamEvent
 from .operations import _init_openai, cancel_run, create_thread_message, get_run, list_thread_messages
 from .utils import execute_connector_action
 from connectors.core.connector import get_logger
-from .constants import LOGGER_NAME, RUN_STATUS_ERROR_MESSAGES, RUN_FINAL_STATUS
+from .constants import *
 
 logger = get_logger(LOGGER_NAME)
 
@@ -22,7 +24,7 @@ class EventHandler(AssistantEventHandler):
     def __init__(self, config, params, last_message_id):
         super().__init__()
         self.run_id = None
-        self.response = {'status': 0, 'message': []}
+        self.response = copy.deepcopy(LLM_RESPONSE)
         self.config = config
         self.params = params
         self.tool_outputs = []
@@ -124,7 +126,7 @@ class EventHandler(AssistantEventHandler):
 
     @override
     def on_end(self):
-        if self.response['status'] == 1:
+        if self.response['status'] != STATUS_SUCCESS:
             return
 
         run_payload = {'run_id': self.run_id, 'thread_id': self.params['thread_id']}
@@ -137,14 +139,13 @@ class EventHandler(AssistantEventHandler):
                 break
 
         # Get the error message as per status
-        error_message = self._get_error_message(status, run_object)
-        if error_message:
-            detailed_error_message = (
-                f"{error_message} \nThread Id: {run_object.get('thread_id')} "
+        self._update_status_from_run(status, run_object)
+        if self.response['status'] != STATUS_SUCCESS:
+            error_details = (
+                f"{self.response['error_details']} \nThread Id: {run_object.get('thread_id')} "
                 f"\nRun Id: {run_object.get('id')} \nAssistant Id: {run_object.get('assistant_id')}"
             )
-            logger.error(detailed_error_message)
-            self.response.update({'status': 1, 'message': error_message})
+            logger.error(error_details)
             return
 
         self.response['message'] = list_thread_messages(
@@ -159,22 +160,27 @@ class EventHandler(AssistantEventHandler):
 
     @override
     def on_exception(self, exception: Exception) -> None:
-        error_message = f"Exception occurred while executing thread: {exception}"
-        logger.error(error_message)
-        self.response.update({'status': 1, 'message': error_message})
+        error_details = f"Exception occurred while executing thread: {exception}"
+        logger.error(error_details)
+        self.response.update({'status': ERROR_OCCURRED, 'error_details': error_details})
 
-    def _get_error_message(self, status, run_object):
-        """Helper method to get the error message based on the status."""
+    def _update_status_from_run(self, status, run_object):
+        """Checks the status and updates the response accordingly."""
         if status == "incomplete":
             reason = run_object.get("incomplete_details", {}).get("reason", "unknown")
             limit = run_object.get(reason, "No additional info")
-            return RUN_STATUS_ERROR_MESSAGES[status].format(reason=reason, limit=limit)
+            error_details = RUN_STATUS_ERROR_MESSAGES[status].format(reason=reason, limit=limit)
+            self.response.update({'status': ERROR_MAX_TOKEN_EXCEEDED, 'error_details': error_details})
+            return error_details
         elif status == "failed":
-            error_message = run_object.get("last_error", {}).get("message", "No details available")
-            return RUN_STATUS_ERROR_MESSAGES[status].format(error_message=error_message)
+            message = run_object.get("last_error", {}).get("message", "No details available")
+            error_details = RUN_STATUS_ERROR_MESSAGES[status].format(error_message=message)
+            self.response.update({'status': ERROR_FAILED, 'error_details': error_details})
+            return error_details
         elif status == "expired":
-            return RUN_STATUS_ERROR_MESSAGES[status]
-        return None
+            error_details = RUN_STATUS_ERROR_MESSAGES[status]
+            self.response.update({'status': ERROR_TIMEOUT, 'error_details': error_details})
+            return error_details
 
     def get_response(self):
         return self.response

--- a/openai/assistant_event_handler.py
+++ b/openai/assistant_event_handler.py
@@ -13,7 +13,7 @@ from openai.types.beta import AssistantStreamEvent
 from .operations import _init_openai, cancel_run, create_thread_message, get_run, list_thread_messages
 from .utils import execute_connector_action
 from connectors.core.connector import get_logger
-from .constants import LOGGER_NAME
+from .constants import LOGGER_NAME, RUN_STATUS_ERROR_MESSAGES, RUN_FINAL_STATUS
 
 logger = get_logger(LOGGER_NAME)
 
@@ -22,7 +22,7 @@ class EventHandler(AssistantEventHandler):
     def __init__(self, config, params, last_message_id):
         super().__init__()
         self.run_id = None
-        self.thread_messages = []
+        self.response = {'status': 1, 'messages': []}
         self.config = config
         self.params = params
         self.tool_outputs = []
@@ -124,17 +124,33 @@ class EventHandler(AssistantEventHandler):
 
     @override
     def on_end(self):
+        if self.response['status'] == 0:
+            return
+
         run_payload = {'run_id': self.run_id, 'thread_id': self.params['thread_id']}
-        run_object = get_run(config=self.config, params=run_payload)
 
-        # wait for the run to get completed or canceled to load the messages
-        while run_object['status'] not in ['completed', 'cancelled']:
+        while True:
             run_object = get_run(config=self.config, params=run_payload)
-            # logger.info(f'Run Status: {run_object.status}')
+            status = run_object['status']
+            logger.info(f'Run Status: {status}')
+            if status in RUN_FINAL_STATUS:
+                break
 
-        self.thread_messages = list_thread_messages(config=self.config,
-                                                    params={'thread_id': self.params['thread_id'],
-                                                            'before': self.last_message_id})
+        # Get the error message as per status
+        error_message = self._get_error_message(status, run_object)
+        if error_message:
+            detailed_error_message = (
+                f"{error_message} \nThread Id: {run_object.get('thread_id')} "
+                f"\nRun Id: {run_object.get('id')} \nAssistant Id: {run_object.get('assistant_id')}"
+            )
+            logger.error(detailed_error_message)
+            self.response.update({'status': 0, 'message': error_message})
+            return
+
+        self.response['message'] = list_thread_messages(
+            config=self.config,
+            params={'thread_id': self.params['thread_id'], 'before': self.last_message_id}
+        )
         # check if more token has been used in function calling
         if self.function_call_token_usage is not None:
             self.token_usage = self.set_token_usage(run_object['usage'])
@@ -143,10 +159,25 @@ class EventHandler(AssistantEventHandler):
 
     @override
     def on_exception(self, exception: Exception) -> None:
-        logger.error(f"Exception occurred while executing thread: {exception}")
+        error_message = f"Exception occurred while executing thread: {exception}"
+        logger.error(error_message)
+        self.response.update({'status': 0, 'message': error_message})
 
-    def get_thread_messages(self):
-        return self.thread_messages
+    def _get_error_message(self, status, run_object):
+        """Helper method to get the error message based on the status."""
+        if status == "incomplete":
+            reason = run_object.get("incomplete_details", {}).get("reason", "unknown")
+            details = run_object.get(reason, "No additional info")
+            return RUN_STATUS_ERROR_MESSAGES[status].format(reason=reason, details=details)
+        elif status == "failed":
+            error_message = run_object.get("last_error", {}).get("message", "No details available")
+            return RUN_STATUS_ERROR_MESSAGES[status].format(error_message=error_message)
+        elif status == "expired":
+            return RUN_STATUS_ERROR_MESSAGES[status]
+        return None
+
+    def get_response(self):
+        return self.response
 
     def call_required_function(self, function_name, arguments):
         try:

--- a/openai/assistant_manager.py
+++ b/openai/assistant_manager.py
@@ -57,7 +57,10 @@ class AssistantManager:
                 response_format=response_format
         ) as stream:
             stream.until_done()
-        return {"llm_response": event_handler.get_thread_messages(), "token_usage": event_handler.token_usage}
+        response = event_handler.get_response()
+        if response['status']:
+            return {"llm_response": response['message'], "token_usage": event_handler.token_usage}
+        raise Exception(response['message'])
 
 
 def get_llm_response(config, params):

--- a/openai/assistant_manager.py
+++ b/openai/assistant_manager.py
@@ -60,9 +60,10 @@ class AssistantManager:
         ) as stream:
             stream.until_done()
         response = event_handler.get_response()
-        if response['status'] == 0:
+        logger.info(f'response: {response}')
+        if response['status'] == STATUS_SUCCESS:
             return {"llm_response": response['message'], "token_usage": event_handler.token_usage}
-        raise Exception(response['message'])
+        raise Exception(response['error_details'])
 
 
 def get_llm_response(config, params):

--- a/openai/assistant_manager.py
+++ b/openai/assistant_manager.py
@@ -54,11 +54,13 @@ class AssistantManager:
                 instructions=instructions,
                 event_handler=event_handler,
                 tool_choice=self.tool_choice,
-                response_format=response_format
+                response_format=response_format,
+                max_prompt_tokens=self.params.get('max_prompt_tokens'),
+                max_completion_tokens=self.params.get('max_completion_tokens')
         ) as stream:
             stream.until_done()
         response = event_handler.get_response()
-        if response['status']:
+        if response['status'] == 0:
             return {"llm_response": response['message'], "token_usage": event_handler.token_usage}
         raise Exception(response['message'])
 

--- a/openai/constants.py
+++ b/openai/constants.py
@@ -42,8 +42,8 @@ FILE_PURPOSE_MAPPING = {
 }
 ATTACHMENT_TOOLS = {"Code Interpreter": "code_interpreter", "File Search": "file_search"}
 RUN_STATUS_ERROR_MESSAGES = {
-    'incomplete': "Error: Response incomplete due to \"{reason}\": {details}.",
-    'failed': "Error: Response failed due to: {error_message}.",
-    'expired': "Error: Response expired due to thread run time out."
+    'incomplete': "Error: OpenAI response incomplete due to \"{reason}\" limit of {limit}.",
+    'failed': "Error: OpenAI response failed due to: {error_message}.",
+    'expired': "Error: OpenAI response expired due to thread run time out."
 }
 RUN_FINAL_STATUS = ['completed', 'cancelled', 'expired', 'failed', 'incomplete']

--- a/openai/constants.py
+++ b/openai/constants.py
@@ -41,3 +41,9 @@ FILE_PURPOSE_MAPPING = {
     "Fine-tune Results": "fine-tune-results"
 }
 ATTACHMENT_TOOLS = {"Code Interpreter": "code_interpreter", "File Search": "file_search"}
+RUN_STATUS_ERROR_MESSAGES = {
+    'incomplete': "Error: Response incomplete due to \"{reason}\": {details}.",
+    'failed': "Error: Response failed due to: {error_message}.",
+    'expired': "Error: Response expired due to thread run time out."
+}
+RUN_FINAL_STATUS = ['completed', 'cancelled', 'expired', 'failed', 'incomplete']

--- a/openai/constants.py
+++ b/openai/constants.py
@@ -47,3 +47,9 @@ RUN_STATUS_ERROR_MESSAGES = {
     'expired': "Error: OpenAI response expired due to thread run time out."
 }
 RUN_FINAL_STATUS = ['completed', 'cancelled', 'expired', 'failed', 'incomplete']
+ERROR_OCCURRED = -1
+STATUS_SUCCESS = 0
+ERROR_MAX_TOKEN_EXCEEDED = 1
+ERROR_TIMEOUT = 2
+ERROR_FAILED = 3
+LLM_RESPONSE = {'status': STATUS_SUCCESS, 'message': {}, 'error_details': ""}


### PR DESCRIPTION
#### Descriptions:
Handle different status of OpenAI Thread Run
Mantis: 1143724

#### Fix:
1. Added logic to check final run status.
2. Added error messages as per there status.

#### UTC:
1. Verified that for run status 'Completed' or 'Cancel', thread messages are being passed on Bot.
2. Verified that for run status 'Failed', last_error from run is being displayed to the User.
3. Verified that for run status 'Expired', time out error message is displayed to the user.
4. Verified that for run status 'Incomplete', incomplete details as 'max_prompt_tokens' or 'max_completion_tokens' is displayed to the user.
5. For other status it get captured in Exception
6. Verified that SOC Assistant conversation is working as expected, example:
    1. Create alert with name as New Alert.
    2. Navigate to alert.
    3. Generate Alert summary.
7. Verified that Playbook Assistant is working as expected, example:
    1. Verified that PB outline is getting generated.
    2. Verified that PB is generating and pasted as expected.
8. Verified that Connector Assistant is working as expected, example:
    1. Connector is getting generated succesfully.


#### Impact
1. Will impact action `get_llm_response`

#### Run Incomplete message
![Run Incomplete message](https://github.com/user-attachments/assets/71c6e9c9-58a5-46f3-b5e7-f10a5a4cc137)


