### PR TITLE
Bug Fix: 1149842

### DIFF
--- a/openai/info.json
+++ b/openai/info.json
@@ -75,8 +75,8 @@
               "visible": true,
               "editable": true,
               "required": true,
-              "placeholder": "2024-05-01-preview",
-              "value": "2024-05-01-preview"
+              "placeholder": "2024-12-01-preview",
+              "value": "2024-12-01-preview"
             },
             {
               "title": "Deployment Name",

--- a/openai/operations.py
+++ b/openai/operations.py
@@ -107,7 +107,7 @@ def chat_completions(config, params):
     openai_args = {"model": model, "messages": messages}
     other_fields = params.get('other_fields', {})
     if config.get("deployment_id"):
-        openai_args.update({"deployment_id": config.get("deployment_id")})
+        openai_args.update({"model": config.get("deployment_id")})
     if temperature:
         openai_args.update({"temperature": temperature})
     if max_tokens:

--- a/openai/release_notes.md
+++ b/openai/release_notes.md
@@ -1,8 +1,11 @@
 #### What's Improved
+
 - Added new actions: Delete File
 - Added support for OpenAI 'Structure Output'
+- For Azure OpenAI changed API Version to '2024-12-01-preview' to support OpenAI Assistant API.
 
 #### Bug Fixes:
+
 - Handled different status of run.
 - Handled not found error.
 - For Azure OpenAI, used AzureOpenAI library instead of OpenAI.


### PR DESCRIPTION
#### Descriptions:
Using Azure OpenAI, failed to use operation: Converse with AI 

#### Fix:
1. For Azure OpenAI, Chat Completion requires 'model' instead of 'deployment_id', so changed same.

#### UTC:
1. Verified that operation get trigged successfully.

